### PR TITLE
Add sequential, reverse, and batch insertion benchmarks

### DIFF
--- a/tests/rb-perf.c
+++ b/tests/rb-perf.c
@@ -386,6 +386,157 @@ static void bench_mixed_operations(int count)
     free(test_nodes);
 }
 
+/* Benchmark batch operations */
+#if _RB_ENABLE_BATCH_OPS
+void sequential_batch_insertion(int count)
+{
+    /* Allocate nodes on heap to avoid stack issues */
+    struct perf_node *test_nodes = calloc(count, sizeof(struct perf_node));
+    if (!test_nodes) {
+        fprintf(stderr, "Failed to allocate memory for %d nodes\n", count);
+        return;
+    }
+
+    /* Initialize tree */
+    rb_t tree;
+    memset(&tree, 0, sizeof(tree));
+    tree.cmp_func = perf_node_lessthan;
+    tree.root = NULL;
+#if _RB_DISABLE_ALLOCA != 0
+    tree.max_depth = 0;
+#endif
+
+    /* Generate unique sequential keys */
+    for (int i = 0; i < count; i++) {
+        test_nodes[i].key = i;
+        /* Initialize node to ensure clean state */
+        memset(&test_nodes[i].node, 0, sizeof(rb_node_t));
+    }
+
+    struct timespec start, end;
+    clock_gettime(CLOCK_MONOTONIC, &start);
+
+    /* Insert nodes */
+    rb_batch_t batch;
+    assert(rb_batch_init(&batch, 0) == 0);
+    for (int i = 0; i < count; i++) {
+        rb_batch_add(&batch, &test_nodes[i].node);
+    }
+    rb_batch_commit(&tree, &batch);
+
+    clock_gettime(CLOCK_MONOTONIC, &end);
+    double elapsed = timespec_diff(&start, &end);
+
+    print_timing("Sequential insertion", count, elapsed);
+
+    free(test_nodes);
+}
+
+void random_batch_insertion(int count)
+{
+    /* Allocate nodes on heap to avoid stack issues */
+    struct perf_node *test_nodes = calloc(count, sizeof(struct perf_node));
+    if (!test_nodes) {
+        fprintf(stderr, "Failed to allocate memory for %d nodes\n", count);
+        return;
+    }
+
+    /* Initialize tree */
+    rb_t tree;
+    memset(&tree, 0, sizeof(tree));
+    tree.cmp_func = perf_node_lessthan;
+    tree.root = NULL;
+#if _RB_DISABLE_ALLOCA != 0
+    tree.max_depth = 0;
+#endif
+
+    /* Generate unique sequential keys */
+    for (int i = 0; i < count; i++) {
+        test_nodes[i].key = i;
+        /* Initialize node to ensure clean state */
+        memset(&test_nodes[i].node, 0, sizeof(rb_node_t));
+    }
+
+    /* Shuffle for random insertion order using Fisher-Yates */
+    for (int i = count - 1; i > 0; i--) {
+        int j = rand() % (i + 1);
+        uint32_t temp = test_nodes[i].key;
+        test_nodes[i].key = test_nodes[j].key;
+        test_nodes[j].key = temp;
+    }
+
+    struct timespec start, end;
+    clock_gettime(CLOCK_MONOTONIC, &start);
+
+    /* Insert nodes */
+    rb_batch_t batch;
+    assert(rb_batch_init(&batch, 0) == 0);
+    for (int i = 0; i < count; i++) {
+        rb_batch_add(&batch, &test_nodes[i].node);
+    }
+    rb_batch_commit(&tree, &batch);
+
+    clock_gettime(CLOCK_MONOTONIC, &end);
+    double elapsed = timespec_diff(&start, &end);
+
+    print_timing("Random insertion", count, elapsed);
+
+    free(test_nodes);
+}
+
+void reverse_batch_insertion(int count)
+{
+    /* Allocate nodes on heap to avoid stack issues */
+    struct perf_node *test_nodes = calloc(count, sizeof(struct perf_node));
+    if (!test_nodes) {
+        fprintf(stderr, "Failed to allocate memory for %d nodes\n", count);
+        return;
+    }
+
+    /* Initialize tree */
+    rb_t tree;
+    memset(&tree, 0, sizeof(tree));
+    tree.cmp_func = perf_node_lessthan;
+    tree.root = NULL;
+#if _RB_DISABLE_ALLOCA != 0
+    tree.max_depth = 0;
+#endif
+
+    /* Generate unique sequential keys */
+    for (int i = 0; i < count; i++) {
+        test_nodes[i].key = count - i;
+        /* Initialize node to ensure clean state */
+        memset(&test_nodes[i].node, 0, sizeof(rb_node_t));
+    }
+
+    struct timespec start, end;
+    clock_gettime(CLOCK_MONOTONIC, &start);
+
+    /* Insert nodes */
+    rb_batch_t batch;
+    assert(rb_batch_init(&batch, 0) == 0);
+    for (int i = 0; i < count; i++) {
+        rb_batch_add(&batch, &test_nodes[i].node);
+    }
+    rb_batch_commit(&tree, &batch);
+
+    clock_gettime(CLOCK_MONOTONIC, &end);
+    double elapsed = timespec_diff(&start, &end);
+
+    print_timing("Reverse insertion", count, elapsed);
+
+    free(test_nodes);
+}
+
+static void bench_batch_insertion(int count)
+{
+    printf("\n=== Batch Insertion Benchmark ===\n");
+    sequential_batch_insertion(count);
+    random_batch_insertion(count);
+    reverse_batch_insertion(count);
+}
+#endif
+
 /* Benchmark cached tree operations */
 #if _RB_ENABLE_LEFTMOST_CACHE || _RB_ENABLE_RIGHTMOST_CACHE
 static void bench_cached_tree(int count)
@@ -505,6 +656,9 @@ int main(int argc, char *argv[])
         bench_search(count);
         bench_deletion(count);
         bench_mixed_operations(count);
+#if _RB_ENABLE_BATCH_OPS
+        bench_batch_insertion(count);
+#endif
 #if _RB_ENABLE_LEFTMOST_CACHE || _RB_ENABLE_RIGHTMOST_CACHE
         bench_cached_tree(count);
 #endif

--- a/tests/rb-perf.c
+++ b/tests/rb-perf.c
@@ -41,12 +41,9 @@ static void print_timing(const char *operation, int count, double elapsed)
            count, elapsed, elapsed / count * 1e6, count / elapsed);
 }
 
-
 /* Benchmark insertion with random keys */
-static void bench_insertion(int count)
+void random_insertion(int count)
 {
-    printf("\n=== Insertion Benchmark ===\n");
-
     /* Allocate nodes on heap to avoid stack issues */
     struct perf_node *test_nodes = calloc(count, sizeof(struct perf_node));
     if (!test_nodes) {
@@ -92,6 +89,95 @@ static void bench_insertion(int count)
     print_timing("Random insertion", count, elapsed);
 
     free(test_nodes);
+}
+/* Benchmark insertion with sequential keys */
+void sequential_insertion(int count)
+{
+    /* Allocate nodes on heap to avoid stack issues */
+    struct perf_node *test_nodes = calloc(count, sizeof(struct perf_node));
+    if (!test_nodes) {
+        fprintf(stderr, "Failed to allocate memory for %d nodes\n", count);
+        return;
+    }
+
+    /* Initialize tree */
+    rb_t tree;
+    memset(&tree, 0, sizeof(tree));
+    tree.cmp_func = perf_node_lessthan;
+    tree.root = NULL;
+#if _RB_DISABLE_ALLOCA != 0
+    tree.max_depth = 0;
+#endif
+
+    /* Generate unique sequential keys */
+    for (int i = 0; i < count; i++) {
+        test_nodes[i].key = i;
+        /* Initialize node to ensure clean state */
+        memset(&test_nodes[i].node, 0, sizeof(rb_node_t));
+    }
+    struct timespec start, end;
+    clock_gettime(CLOCK_MONOTONIC, &start);
+
+    /* Insert nodes */
+    for (int i = 0; i < count; i++) {
+        rb_insert(&tree, &test_nodes[i].node);
+    }
+
+    clock_gettime(CLOCK_MONOTONIC, &end);
+    double elapsed = timespec_diff(&start, &end);
+
+    print_timing("Sequential insertion", count, elapsed);
+
+    free(test_nodes);
+}
+
+/* Benchmark insertion with reverse keys */
+void reverse_insertion(int count)
+{
+    /* Allocate nodes on heap to avoid stack issues */
+    struct perf_node *test_nodes = calloc(count, sizeof(struct perf_node));
+    if (!test_nodes) {
+        fprintf(stderr, "Failed to allocate memory for %d nodes\n", count);
+        return;
+    }
+
+    /* Initialize tree */
+    rb_t tree;
+    memset(&tree, 0, sizeof(tree));
+    tree.cmp_func = perf_node_lessthan;
+    tree.root = NULL;
+#if _RB_DISABLE_ALLOCA != 0
+    tree.max_depth = 0;
+#endif
+
+    /* Generate unique sequential keys */
+    for (int i = 0; i < count; i++) {
+        test_nodes[i].key = count - i;
+        /* Initialize node to ensure clean state */
+        memset(&test_nodes[i].node, 0, sizeof(rb_node_t));
+    }
+    struct timespec start, end;
+    clock_gettime(CLOCK_MONOTONIC, &start);
+
+    /* Insert nodes */
+    for (int i = 0; i < count; i++) {
+        rb_insert(&tree, &test_nodes[i].node);
+    }
+
+    clock_gettime(CLOCK_MONOTONIC, &end);
+    double elapsed = timespec_diff(&start, &end);
+
+    print_timing("Reverse insertion", count, elapsed);
+
+    free(test_nodes);
+}
+
+static void bench_insertion(int count)
+{
+    printf("\n=== Insertion Benchmark ===\n");
+    sequential_insertion(count);
+    random_insertion(count);
+    reverse_insertion(count);
 }
 
 /* Benchmark search operations */


### PR DESCRIPTION
Add sequential/reverse insertion benchmarks and batch insertion (sequential, reverse, random)

Preliminary Results (On Apple M1):
Batch insertion shows ~2×–2.7× speedup over regular insertion.
```
$ ./rb-perf 50000000
Red-Black Tree Performance Benchmark
=====================================
Benchmarking with 50000000 nodes:

=== Insertion Benchmark ===
Sequential insertion: 50000000 ops in 13.516 sec (0.270 µs/op, 3699253 ops/sec)
Random insertion    : 50000000 ops in 55.403 sec (1.108 µs/op, 902481 ops/sec)
Reverse insertion   : 50000000 ops in 15.330 sec (0.307 µs/op, 3261534 ops/sec)

=== Search Benchmark ===
Search existing     : 50000000 ops in 50.603 sec (1.012 µs/op, 988085 ops/sec)
Found 50000000/50000000 nodes

=== Deletion Benchmark ===
Random deletion     : 50000000 ops in 61.159 sec (1.223 µs/op, 817545 ops/sec)

=== Mixed Operations Benchmark ===
Mixed operations    : 125000000 ops in 71.226 sec (0.570 µs/op, 1754982 ops/sec)
  - Inserts: 50000000, Searches: 55000030, Deletes: 19999970

=== Batch Insertion Benchmark ===
Sequential insertion: 50000000 ops in 5.610 sec (0.112 µs/op, 8911949 ops/sec)
Random insertion    : 50000000 ops in 17.725 sec (0.354 µs/op, 2820917 ops/sec)
Reverse insertion   : 50000000 ops in 6.809 sec (0.136 µs/op, 7342974 ops/sec)

=== Cached Tree Benchmark ===
Cached insertion    : 50000000 ops in 57.080 sec (1.142 µs/op, 875962 ops/sec)
Get min (cached)    : 10000 ops in 0.000 sec (0.000 µs/op, inf ops/sec)
Get min (regular)   : 10000 ops in 0.000 sec (0.018 µs/op, 56818182 ops/sec)
Cached speedup: >1000x (too fast to measure)
```